### PR TITLE
Removed pisr/utils/types.py

### DIFF
--- a/pisr/sampling.py
+++ b/pisr/sampling.py
@@ -1,7 +1,13 @@
-from .utils.types import TypeTensor
+from typing import TypeVar
+
+import torch
+import numpy as np
 
 
-def get_low_res_grid(high_res: TypeTensor, factor: int = 3) -> TypeTensor:
+T = TypeVar('T', np.ndarray, torch.Tensor)
+
+
+def get_low_res_grid(high_res: T, factor: int = 3) -> T:
 
     """Produces low-resolution grid from high-resolution grid.
 
@@ -10,14 +16,14 @@ def get_low_res_grid(high_res: TypeTensor, factor: int = 3) -> TypeTensor:
 
     Parameters:
     ===========
-    high_res: TypeTensor
+    high_res: np.ndarray | torch.Tensor
         High-resolution field to generate low-resolution field from.
     factor: int
         Odd factor by which to downsample the high-resolution field.
 
     Returns:
     ========
-    low_res: TypeTensor
+    low_res: np.ndarray | torch.Tensor
         Low-resolution field sampled from high-resolution field.
     """
 

--- a/pisr/utils/checks.py
+++ b/pisr/utils/checks.py
@@ -1,12 +1,17 @@
 import functools as ft
 import itertools as it
-from typing import Any, Callable, ParamSpec, TypeVar
+from typing import Any, Callable, ParamSpec, TypeAlias, TypeVar
+
+import torch
+import numpy as np
 
 from .exceptions import DimensionError, DimensionWarning
-from .types import TypeTensor
+
 
 P = ParamSpec('P')
 T = TypeVar('T')
+
+TypeTensor: TypeAlias = np.ndarray | torch.Tensor
 
 
 class ValidateDimension:

--- a/pisr/utils/types.py
+++ b/pisr/utils/types.py
@@ -1,8 +1,0 @@
-from typing import TypeVar, Union
-
-import numpy as np
-import torch
-
-TypeTensor = np.ndarray | torch.Tensor
-T = TypeVar('T', np.ndarray, torch.Tensor)
-


### PR DESCRIPTION
No longer required the `pisr/utils/types.py` file.
Updated redundant usages to use `TypeVar` where more applicable.

Resolves: # 18
